### PR TITLE
improve speed keeping tcp connection in the state

### DIFF
--- a/lib/output/tcp.ex
+++ b/lib/output/tcp.ex
@@ -1,15 +1,9 @@
 defmodule Logger.Backend.Logentries.Output.Tcp do
-  def transmit(host, port, message) do
+  def open(host, port) do
     :gen_tcp.connect(host, port, [:binary, active: false])
-    |> tcp_send(message)
   end
 
-  defp tcp_send({:error, error}, _message) do
-    raise "Error sending via tcp: #{error}"
-  end
-
-  defp tcp_send({:ok, socket}, message) do
+  def transmit(socket, message) do
     :gen_tcp.send(socket, message)
-    :gen_tcp.close(socket)
   end
 end


### PR DESCRIPTION
Hello guys, thanks for sharing you library.
In the last days our application was responding really slowly, and after a day of debugging I found out that the reason was the logentries backend implementation.

In the current implementation the backend opens a tcp connection to logentries for each log entry.
In this PR I changed the code to keep the connection in the state and it seems to be much faster.

After this the time per request changed from 107ms to  5ms, you can find the full benchmark here: https://gist.github.com/pilu/d24160661fce9b0470f1b8c03cbcff62

It's not a definitive fix because we need to handle connection problems and retry to open the connection, but for now I think it could work.

I hope you can review this PR soon, 
Looking forward to hearing from you guys
