### PR TITLE
bugfix(Logger): move aut token to the beginning of the log message

### DIFF
--- a/lib/logger_logentries_backend.ex
+++ b/lib/logger_logentries_backend.ex
@@ -44,7 +44,7 @@ defmodule Logger.Backend.Logentries do
   end
 
   defp log_event(level, msg, ts, md, %{connector: connector, connection: connection, token: token} = state) do
-    log_entry = format_event(level, "#{msg} #{token}", ts, md, state)
+    log_entry = format_event(level, "#{token} #{msg}", ts, md, state)
     connector.transmit(connection, log_entry)
     state
   end


### PR DESCRIPTION
Each log message contains the authentication token, and logentries
allows the token to be everywhere in the message sent.
Previously the token was at the end of the message.
In case the message contained another UUID, logentries used it as
an authentication token and skipped the real one that was at the end of
the message.
For this reason, all the logs with a UUID inside where not saved in
logentries.
