### PR TITLE
Fix compiler warnings

### DIFF
--- a/lib/logger_logentries_backend.ex
+++ b/lib/logger_logentries_backend.ex
@@ -1,5 +1,5 @@
 defmodule Logger.Backend.Logentries do
-  use GenEvent
+  @behaviour :gen_event
 
   require Logger
 
@@ -27,6 +27,18 @@ defmodule Logger.Backend.Logentries do
     else
       state
     end
+    {:ok, state}
+  end
+
+  def handle_info(_msg, state) do
+    {:ok, state}
+  end
+
+  def terminate(_reason, _state) do
+    :ok
+  end
+
+  def code_change(_old, state, _extra) do
     {:ok, state}
   end
 

--- a/lib/logger_logentries_backend.ex
+++ b/lib/logger_logentries_backend.ex
@@ -17,7 +17,7 @@ defmodule Logger.Backend.Logentries do
     {:ok, {:ok, connector}, state}
   end
 
-  def handle_call(:remove_connection, %{name: name} = state) do
+  def handle_call(:remove_connection, %{name: _name} = state) do
     {:ok, :ok, %{state | connection: nil}}
   end
 
@@ -38,7 +38,7 @@ defmodule Logger.Backend.Logentries do
     open_connection(state) |> open_connection_and_log_event(level, msg, ts, md, false)
   end
 
-  def open_connection_and_log_event(%{connection: connection} = state, level, msg, ts, md, retry) when is_nil(connection) and retry == false do
+  def open_connection_and_log_event(%{connection: connection} = state, _level, _msg, _ts, _md, retry) when is_nil(connection) and retry == false do
     Logger.error("connection to logentries is not open")
     state
   end

--- a/mix.exs
+++ b/mix.exs
@@ -8,9 +8,9 @@ defmodule LoggerLogentriesBackend.Mixfile do
       elixir: "~> 1.0",
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,
-      description: description,
-      package: package,
-      deps: deps
+      description: description(),
+      package: package(),
+      deps: deps()
     ]
   end
 

--- a/test/logger_logentries_backend_test.exs
+++ b/test/logger_logentries_backend_test.exs
@@ -43,7 +43,7 @@ defmodule Logger.Backend.Logentries.Test do
       metadata_filter: []
     ])
     on_exit fn ->
-      connector.destroy()
+      connector().destroy()
       remove_connection()
     end
     :ok

--- a/test/logger_logentries_backend_test.exs
+++ b/test/logger_logentries_backend_test.exs
@@ -111,7 +111,7 @@ defmodule Logger.Backend.Logentries.Test do
   end
 
   defp connector() do
-    {:ok, connector} = GenEvent.call(Logger, @backend, :connector)
+    {:ok, connector} = :gen_event.call(Logger, @backend, :connector)
     connector
   end
 
@@ -120,6 +120,6 @@ defmodule Logger.Backend.Logentries.Test do
   end
 
   defp remove_connection() do
-    :ok = GenEvent.call(Logger, @backend, :remove_connection)
+    :ok = :gen_event.call(Logger, @backend, :remove_connection)
   end
 end


### PR DESCRIPTION
Prior to this the library was generating several compiler warnings,
primarily related to unused variables and assumed function calls.
We also had deprecation warnings related to `GenEvent`. This PR
converts `GenEvent` to `:gen_event` and maintains the prior
functionality.