### PR TITLE
fix(README): runtime configuration UndefinedFunctionError

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Then run mix deps.get to install it.
 
 ```elixir
 Logger.add_backend {Logger.Backend.Logentries, :debug}
-Logger.configure {Logger.Backend.Logentries, :debug},
+Logger.configure_backend {Logger.Backend.Logentries, :debug},
   host: 'data.logentries.com',
   port: 10000,
   token: "logentries-token-goes-here",


### PR DESCRIPTION
_(UndefinedFunctionError) function Logger.configure/2_

Fixing Runtime configuration Logger.configure_backend/2 instead of Logger.configure/1