### PR TITLE
Make the warnings go away.

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -8,9 +8,9 @@ defmodule LoggerLogentriesBackend.Mixfile do
       elixir: "~> 1.0",
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,
-      description: description,
-      package: package,
-      deps: deps
+      description: description(),
+      package: package(),
+      deps: deps()
     ]
   end
 


### PR DESCRIPTION
The lack of parens has been making Elixir 1.7 unhappy for a while now. Time for the warnings to end.