### PR TITLE
replace newlines by spaces in the log message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ erl_crash.dump
 *.ez
 .DS_Store
 *.swp
+.elixir_ls

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Then run mix deps.get to install it.
 
 ```elixir
 Logger.add_backend {Logger.Backend.Logentries, :debug}
-Logger.configure {Logger.Backend.Logentries, :debug},
+Logger.configure_backend {Logger.Backend.Logentries, :debug},
   host: 'data.logentries.com',
   port: 10000,
   token: "logentries-token-goes-here",

--- a/lib/logger_logentries_backend.ex
+++ b/lib/logger_logentries_backend.ex
@@ -44,11 +44,16 @@ defmodule Logger.Backend.Logentries do
   end
 
   defp log_event(level, msg, ts, md, %{connector: connector, connection: connection, token: token} = state) do
-    msg = String.replace(msg, "\n", " ", global: true)
+    msg = maybe_replace_newlines(msg)
     log_entry = format_event(level, "#{token} #{msg}", ts, md, state)
     connector.transmit(connection, log_entry)
     state
   end
+
+  defp maybe_replace_newlines(msg) when is_binary(msg) do
+    String.replace(msg, "\n", " ", global: true)
+  end
+  defp maybe_replace_newlines(msg), do: msg
 
   defp format_event(level, msg, ts, md, %{format: format, metadata: keys}) do
     Logger.Formatter.format(format, level, msg, ts, take_metadata(md, keys))

--- a/lib/logger_logentries_backend.ex
+++ b/lib/logger_logentries_backend.ex
@@ -56,6 +56,7 @@ defmodule Logger.Backend.Logentries do
   end
 
   defp log_event(level, msg, ts, md, %{connector: connector, connection: connection, token: token} = state) do
+    msg = String.replace(msg, "\n", " ", global: true)
     log_entry = format_event(level, "#{token} #{msg}", ts, md, state)
     connector.transmit(connection, log_entry)
     state

--- a/lib/logger_logentries_backend.ex
+++ b/lib/logger_logentries_backend.ex
@@ -1,5 +1,5 @@
 defmodule Logger.Backend.Logentries do
-  use GenEvent
+  @behaviour :gen_event
 
   require Logger
 
@@ -27,6 +27,18 @@ defmodule Logger.Backend.Logentries do
     else
       state
     end
+    {:ok, state}
+  end
+
+  def handle_info(_msg, state) do
+    {:ok, state}
+  end
+
+  def terminate(_reason, _state) do
+    :ok
+  end
+
+  def code_change(_old, state, _extra) do
     {:ok, state}
   end
 

--- a/lib/logger_logentries_backend.ex
+++ b/lib/logger_logentries_backend.ex
@@ -17,7 +17,7 @@ defmodule Logger.Backend.Logentries do
     {:ok, {:ok, connector}, state}
   end
 
-  def handle_call(:remove_connection, %{name: name} = state) do
+  def handle_call(:remove_connection, %{name: _name} = state) do
     {:ok, :ok, %{state | connection: nil}}
   end
 
@@ -38,7 +38,7 @@ defmodule Logger.Backend.Logentries do
     open_connection(state) |> open_connection_and_log_event(level, msg, ts, md, false)
   end
 
-  def open_connection_and_log_event(%{connection: connection} = state, level, msg, ts, md, retry) when is_nil(connection) and retry == false do
+  def open_connection_and_log_event(%{connection: connection} = state, _level, _msg, _ts, _md, retry) when is_nil(connection) and retry == false do
     Logger.error("connection to logentries is not open")
     state
   end

--- a/lib/logger_logentries_backend.ex
+++ b/lib/logger_logentries_backend.ex
@@ -44,6 +44,7 @@ defmodule Logger.Backend.Logentries do
   end
 
   defp log_event(level, msg, ts, md, %{connector: connector, connection: connection, token: token} = state) do
+    msg = String.replace(msg, "\n", " ", global: true)
     log_entry = format_event(level, "#{token} #{msg}", ts, md, state)
     connector.transmit(connection, log_entry)
     state

--- a/mix.exs
+++ b/mix.exs
@@ -8,9 +8,9 @@ defmodule LoggerLogentriesBackend.Mixfile do
       elixir: "~> 1.0",
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,
-      description: description,
-      package: package,
-      deps: deps
+      description: description(),
+      package: package(),
+      deps: deps()
     ]
   end
 

--- a/test/logger_logentries_backend_test.exs
+++ b/test/logger_logentries_backend_test.exs
@@ -67,6 +67,14 @@ defmodule Logger.Backend.Logentries.Test do
     assert read_log() == "[warn] <<logentries-token>> you will log me\n"
   end
 
+  test "replaces \n in the msg by empty spaces" do
+    refute connector().exists()
+    config(level: :info)
+    Logger.warn("you\nwill\nlog\nme")
+    assert connector().exists()
+    assert read_log() == "[warn] <<logentries-token>> you will log me\n"
+  end
+
   test "can configure format" do
     config format: "$message ($level)\n"
 

--- a/test/logger_logentries_backend_test.exs
+++ b/test/logger_logentries_backend_test.exs
@@ -111,7 +111,7 @@ defmodule Logger.Backend.Logentries.Test do
   end
 
   defp connector() do
-    {:ok, connector} = GenEvent.call(Logger, @backend, :connector)
+    {:ok, connector} = :gen_event.call(Logger, @backend, :connector)
     connector
   end
 
@@ -120,6 +120,6 @@ defmodule Logger.Backend.Logentries.Test do
   end
 
   defp remove_connection() do
-    :ok = GenEvent.call(Logger, @backend, :remove_connection)
+    :ok = :gen_event.call(Logger, @backend, :remove_connection)
   end
 end


### PR DESCRIPTION
I was seeing my Channel logs incomplete because Phoenix inserts \n in them.
With this approach I replaced \n with " " before logging.