### PR TITLE
fix(Logger): replacing newlines by spaces in binary log msgs

### DIFF
--- a/lib/logger_logentries_backend.ex
+++ b/lib/logger_logentries_backend.ex
@@ -44,10 +44,15 @@ defmodule Logger.Backend.Logentries do
   end
 
   defp log_event(level, msg, ts, md, %{connector: connector, connection: connection, token: token} = state) do
-    log_entry = format_event(level, "#{token} #{msg}", ts, md, state)
+    log_entry = format_event(level, "#{token} #{maybe_replace_newlines(msg)}", ts, md, state)
     connector.transmit(connection, log_entry)
     state
   end
+
+  defp maybe_replace_newlines(msg) when is_binary(msg) do
+    String.replace(msg, "\n", " ", global: true)
+  end
+  defp maybe_replace_newlines(msg), do: msg
 
   defp format_event(level, msg, ts, md, %{format: format, metadata: keys}) do
     Logger.Formatter.format(format, level, msg, ts, take_metadata(md, keys))

--- a/test/logger_logentries_backend_test.exs
+++ b/test/logger_logentries_backend_test.exs
@@ -67,6 +67,14 @@ defmodule Logger.Backend.Logentries.Test do
     assert read_log() == "[warn] <<logentries-token>> you will log me\n"
   end
 
+  test "replaces \n in a binary msg by empty spaces" do
+    refute connector().exists()
+    config(level: :info)
+    Logger.warn("you\nwill\nlog\nme")
+    assert connector().exists()
+    assert read_log() == "[warn] <<logentries-token>> you will log me\n"
+  end
+
   test "can configure format" do
     config format: "$message ($level)\n"
 


### PR DESCRIPTION
replacing \n with spaces, sice I was getting incomplete logs.
it's just for binary msgs.